### PR TITLE
build(docker): Rework docker-publish workflow for RSICV support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract Docker metadata

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,6 @@ on:
 # Variables
 # --------------------------------------------------------------
 env:
-  IMAGE_NAME: boosterl/can-i-charge
   PLATFORMS: linux/amd64,linux/arm64
 
 
@@ -51,7 +50,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ github.repository }}
 
       - name: Build and push image
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ on:
 # --------------------------------------------------------------
 env:
   IMAGE_NAME: boosterl/can-i-charge
-  PLATFORMS: linux/amd64,linux/arm64,linux/riscv64
+  PLATFORMS: linux/amd64,linux/arm64
 
 
 # --------------------------------------------------------------

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,61 +1,65 @@
-name: Build latest
+name: Docker
 
+# This workflow can be triggered by two events: a published release or a 
+# manual dispatch. When triggered by a release, it pushes a Docker image 
+#tagged with both 'latest' and the release version. If triggered manually, 
+# the Docker image is tagged with the branch name (e.g., main, dev etc).
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
   release:
     types: [published]
-  schedule:
-    # Build the image daily
-    - cron: '0 3 * * *'
+  workflow_dispatch:
 
+
+# --------------------------------------------------------------
+# Variables
+# --------------------------------------------------------------
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/can-i-charge
-  TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || 'latest' }}
+  IMAGE_NAME: boosterl/can-i-charge
+  PLATFORMS: linux/amd64,linux/arm64,linux/riscv64
 
+
+# --------------------------------------------------------------
+# Jobs
+# --------------------------------------------------------------
 jobs:
-  build:
-    name: Build & push new image
+  docker:
+    name: Docker build and push
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ env.PLATFORMS }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          platforms: linux/amd64, linux/arm64
 
-      - name: Login to registry
-        if: github.event_name != 'pull_request'
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set Docker metadata
+      - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            ${{ env.TAG }}
+          images: ghcr.io/${{ env.IMAGE_NAME }}
 
-      - name: Build and push Docker image for amd64 and arm64
-        id: build-and-push
+      - name: Build and push image
         uses: docker/build-push-action@v6
         with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64, linux/arm64
+          platforms: ${{ env.PLATFORMS }}
+          # Prevents the unknown/unknown arch
+          # see https://github.com/docker/build-push-action/issues/820
+          provenance: false


### PR DESCRIPTION
## Description
This pull request introduces several changes to the existing `docker-publish` workflow with main one being support for RSICV Docker images

### Changes:
1. **Support for RSICV images**:
   - The workflow has been reworked to make building RSICV Docker images possible.

2. **Removal of scheduled trigger**:
   - The `schedule` trigger (which built images every night at 3 AM) has been removed. (I don't think nightly builds are necessary for this project)

3. **Revised tagging behavior**:
   - For release events, the Docker image is now tagged with both `latest` and the release version (e.g., `v1.0.0`).
   - For manual triggers, the image is tagged with the branch name (e.g., `main`, `dev`, etc.), providing clear identification of the build source.

4. **Fix the unknown/unknown arch**:
   - When not building OCI images the `docker/build-push-action@v6` action will cause a `unknown/unknown` arch to show up under packages. This can be fixed by setting `provenance` to false.